### PR TITLE
fix: remove dead onStartAnalysis callback causing TS build failure

### DIFF
--- a/src/pages/MaintenancePage.tsx
+++ b/src/pages/MaintenancePage.tsx
@@ -55,10 +55,6 @@ export default function MaintenancePage() {
   const [activeTab, setActiveTab] = useState<Tab>('dashboard');
   const { reports } = useMaintenanceReports();
 
-  const handleStartAnalysisFromReport = useCallback((_file: File, _reportId: string) => {
-    setActiveTab('analysis');
-  }, []);
-
   const handleToastClick = useCallback((reportId: string) => {
     setActiveTab('reports');
     void reportId;
@@ -94,7 +90,7 @@ export default function MaintenancePage() {
           <AnalysisTab />
         </div>
         <div style={{ display: activeTab === 'reports' ? undefined : 'none' }}>
-          <ReportsTab reports={reports} onStartAnalysis={handleStartAnalysisFromReport} />
+          <ReportsTab reports={reports} />
         </div>
         <div style={{ display: activeTab === 'dashboard' ? undefined : 'none' }}>
           <DashboardTab reports={reports} />

--- a/src/pages/maintenance/ReportsTab.tsx
+++ b/src/pages/maintenance/ReportsTab.tsx
@@ -77,15 +77,6 @@ export default function ReportsTab({ reports }: Props) {
     }
   }, [activeReportId, waypoint]);
 
-  const handleFootageReady = useCallback(
-    (file: File) => {
-      if (activeReportId) {
-        onStartAnalysis(file, activeReportId);
-      }
-    },
-    [activeReportId, onStartAnalysis],
-  );
-
   const isFiltered = priorityFilter !== '' || statusFilter !== '';
 
   return (


### PR DESCRIPTION
## Summary
- `ReportsTab.tsx` had a `handleFootageReady` callback referencing `onStartAnalysis`, which was never added to the component's `Props` interface after a refactor
- `MaintenancePage.tsx` was still passing `onStartAnalysis` as a prop to `ReportsTab`, which TypeScript rejected
- Removed the dead callback and the orphaned prop

## Files changed
- `src/pages/maintenance/ReportsTab.tsx` — removed `handleFootageReady` (7 lines)
- `src/pages/MaintenancePage.tsx` — removed `handleStartAnalysisFromReport` callback and prop pass-through (6 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)